### PR TITLE
Fix Line comment and block comment for Qlik Script is not defined #8

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -1,7 +1,14 @@
 {
+     "comments": {
+        // single line comment in qlik script. 
+        "lineComment": "//",
+        // Block comment in qlik script
+        "blockComment": [ "/*", "*/" ]
+    },
     "brackets": [
       ["{", "}"],
       ["[", "]"],
       ["(", ")"]
   ]
 }
+


### PR DESCRIPTION
Adds definitions for line and block comments to qlik script 

- Line: `//`
- Block `/*`,`*/`
